### PR TITLE
chore: update agent requirements and .gitignore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,10 @@ All agents must follow these rules:
    - Common: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, `perf:`
    - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
 3) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
-4) PR descriptions must include Summary, Rationale, and Details sections.
+4) PR descriptions must include `Summary`, `Rationale`, and `Details` sections.
 5) Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.
-8) The mypy configuration should go in pyproject.toml.
+8) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,12 @@ All agents must follow these rules:
    - Common: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, `perf:`
    - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
 3) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
-4) PR descriptions must include `Summary`, `Rationale`, and `Details` sections.
+4) PR descriptions must include Summary, Rationale, and Details sections.
 5) Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.
-8) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
+8) Maximize the use of caching in GitHub workflow files to minimize run duration.
+9) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
+10) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary
- Update `AGENTS.md` to reflect current contributor requirements.
- Add `.worktrees/` to `.gitignore`.

Rationale
- Keep contributor guidance consistent across repos.
- Avoid accidental commits of local worktree directories.

Details
- Applies the latest agent requirement rules for this repo.
- Ignores local worktree directories used during validation.
