### PR TITLE
docs: add agent requirements for consistent automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,5 @@ All agents must follow these rules:
 5) Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.
-8) Maximize the use of caching in GitHub workflow files to minimize run duration.
-9) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
-10) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary
- Add `AGENTS.md` with repo-specific agent requirements.

Rationale
- Keep automated contributions aligned with repository standards.

Details
- Rules derived from the repo's characteristics (language, tooling).
