### PR TITLE
chore: update AGENTS remote-branch guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,5 +11,6 @@ All agents must follow these rules:
 5) Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.
+8) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary:
- Add guidance in `AGENTS.md` to fetch and update a remote-tracking branch before starting work.

Rationale:
- Ensures changes begin from the latest remote state to avoid stale bases and conflicts.

Details:
- Document the remote-branch update step in `AGENTS.md`.