### PR TITLE
fix(cicd): scope workflow triggers for sphinx-autodoc-vyper

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - '.github/workflows/black.yaml'
+      - 'sphinx_autodoc_vyper/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.py'
 
 jobs:
   format:
@@ -41,5 +47,5 @@ jobs:
         git config --local user.name "github-actions[bot]"
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git add .
-        git commit -m "chore: \`black .\`"
+        git commit -m "chore: `black .`"
         git push

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,8 +3,22 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    paths:
+      - '.github/workflows/codeql.yaml'
+      - 'sphinx_autodoc_vyper/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'tox.ini'
   pull_request:
     branches: [ main ]
+    paths:
+      - '.github/workflows/codeql.yaml'
+      - 'sphinx_autodoc_vyper/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'tox.ini'
   schedule:
     - cron: '30 1 * * 0'
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,8 +3,20 @@ name: Lint
 on:
   push:
     branches: [ main ]
+    paths:
+      - '.github/workflows/lint.yaml'
+      - 'sphinx_autodoc_vyper/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.py'
   pull_request:
     branches: [ main ]
+    paths:
+      - '.github/workflows/lint.yaml'
+      - 'sphinx_autodoc_vyper/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.py'
 
 jobs:
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,8 +3,22 @@ name: Tests
 on:
   push:
     branches: [ main ]
+    paths:
+      - '.github/workflows/test.yaml'
+      - 'sphinx_autodoc_vyper/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'tox.ini'
   pull_request:
     branches: [ main ]
+    paths:
+      - '.github/workflows/test.yaml'
+      - 'sphinx_autodoc_vyper/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'tox.ini'
 
 jobs:
   test:


### PR DESCRIPTION
Summary
- Add path filters to codeql, test, lint, and black workflows so they run on relevant changes.

Rationale
- Align workflow triggers with the AGENTS path-filter requirement while reducing unnecessary CI runs.

Details
- Update `.github/workflows/codeql.yaml`, `.github/workflows/test.yaml`, `.github/workflows/lint.yaml`, and `.github/workflows/black.yaml` to include `paths` filters.
- Tests: `uv run --python 3.11 --with tox tox -e py311`